### PR TITLE
Implement better line rendering methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 [[package]]
 name = "lsystems-core"
 version = "0.2.0"
-source = "git+https://github.com/nshcat/lsystems-core#cd3ec5cf2b28c2348d8b152df0f09d3d6f2a6a98"
+source = "git+https://github.com/nshcat/lsystems-core#d1298fdba857f310d09f6ff1c584f57351b36302"
 dependencies = [
  "nalgebra 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "peg 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -14,6 +14,18 @@ pub mod presets;
 pub mod bezier;
 
 
+/// Enumeration describing the different line rendering modes that can be used by a
+/// lsystem.
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[repr(u32)]
+pub enum LineDrawMode {
+	/// Use built-in OpenGL line rendering. Can only do a width of 1.0.
+	Basic = 0,
+	/// 2D lines made out of triangle strips with arbitrary width.
+	Advanced2D = 1,
+	/// 3D, tube-like lines.
+	Advanced3D = 2
+}
 
 /// A special structure used to represent a single interpretation mapping.
 /// This is only used with the GUI, and the Option allows the user to have interpretations
@@ -76,6 +88,7 @@ pub struct LSystemParameters {
 	pub camera_theta: f64,
 	pub axiom: String,
 	pub seed: u64,
+	pub line_draw_mode: LineDrawMode,
 	pub iteration_depth: u32,
 	pub rules: Vec<String>,
 	/// The usage of a Vec instead of a associative container is done in order to preserve

--- a/src/data/presets/empty.json
+++ b/src/data/presets/empty.json
@@ -17,6 +17,7 @@
   "camera_phi": 0.0,
   "camera_theta": 0.0,
   "axiom": "",
+  "line_draw_mode": "Basic",
   "seed": 0,
   "iteration_depth": 1,
   "rules": [

--- a/src/data/presets/koch.json
+++ b/src/data/presets/koch.json
@@ -18,6 +18,7 @@
   "camera_theta": 0.0,
   "axiom": "F--F--F",
   "seed": 0,
+  "line_draw_mode": "Basic",
   "iteration_depth": 2,
   "rules": [
     "F -> F+F--F+F"

--- a/src/data/presets/penrose.json
+++ b/src/data/presets/penrose.json
@@ -15,6 +15,7 @@
   "modify_camera": false,
   "camera_radius": 0.0,
   "camera_phi": 0.0,
+  "line_draw_mode": "Basic",
   "camera_theta": 0.0,
   "axiom": "[7]++[7]++[7]++[7]++[7]",
   "seed": 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use crate::scene::lsystem::*;
 fn main() {
 	let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
     glfw.window_hint(glfw::WindowHint::ContextVersion(3, 3)); 
+    glfw.window_hint(glfw::WindowHint::Samples(Some(4u32)));
 
     let (mut window, events) = glfw
         .create_window(

--- a/src/rendering/camera.rs
+++ b/src/rendering/camera.rs
@@ -125,7 +125,7 @@ impl Camera {
 
     /// Extract relevant camera information to use in a rendering operation
     pub fn to_render_parameters(&self) -> RenderParameters {
-        RenderParameters::new(self.view, self.projection)
+        RenderParameters::new(self.camera_position(), self.view, self.projection)
     }
 
     /// An internal method used to update the view matrix after camera state

--- a/src/rendering/meshes.rs
+++ b/src/rendering/meshes.rs
@@ -759,7 +759,9 @@ pub enum PrimitiveType {
     Lines = gl::LINES,
     LineStrip = gl::LINE_STRIP,
     LineLoop = gl::LINE_LOOP,
-    Points = gl::POINTS
+    Points = gl::POINTS,
+    LinesAdjacency = gl::LINES_ADJACENCY,
+    LineStripAdjacency = gl::LINE_STRIP_ADJACENCY
 }
 
 /// A mesh is a combination of geometry and a material, which can not be changed.

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -10,6 +10,7 @@ pub mod materials;
 pub mod model;
 pub mod lighting;
 pub mod bezier;
+pub mod primitives;
 
 use crate::rendering::lighting::*;
 use nalgebra_glm::{Mat4, Vec3};
@@ -36,25 +37,28 @@ pub struct RenderParameters {
     /// The model transformation matrix
     pub model: Mat4,
     /// The current lighting context
-    pub lighting: LightingContext
+    pub lighting: LightingContext,
+    /// The position of the camera, in world space.
+    pub camera_position: Vec3
 }
 
 impl RenderParameters {
     /// Create a new instance based on given projection and view matrices.
-    pub fn new(view: Mat4, proj: Mat4) -> RenderParameters {
+    pub fn new(pos: Vec3, view: Mat4, proj: Mat4) -> RenderParameters {
         RenderParameters {
             view: view,
             projection: proj,
             matrix_stack: Vec::new(),
             model: Mat4::identity(),
-            lighting: LightingContext::new_default()
+            lighting: LightingContext::new_default(),
+            camera_position: pos
         }
     }
 
     /// Create a new render parameters instance that contains only identity matrices.
     /// For testing purposes only.
     pub fn identity() -> RenderParameters {
-        Self::new(Mat4::identity(), Mat4::identity())
+        Self::new(Vec3::zeros(), Mat4::identity(), Mat4::identity())
     }
 
     /// Push the current model matrix on to the matrix stack, saving it for later restoration.

--- a/src/rendering/primitives/line.rs
+++ b/src/rendering/primitives/line.rs
@@ -1,0 +1,377 @@
+use nalgebra_glm::{Mat4, Vec3, Vec2};
+use std::any::*;
+use crate::rendering::*;
+use crate::rendering::meshes::*;
+use crate::rendering::materials::*;
+use crate::rendering::shaders::*;
+use crate::rendering::uniforms::*;
+use crate::rendering::traits::*;
+
+/// Geometry type used by all types of lines. Vertices contain both color and line width
+/// attributes.
+pub struct LineGeometry {
+    pub positions: AttributeArray<Vec3>,
+    pub colors: AttributeArray<Vec3>,
+    pub widths: AttributeArray<f32>,
+    pub indices: Vec<u32>
+}
+
+impl LineGeometry {
+    /// Create a new, empty line geometry instance.
+    pub fn new() -> LineGeometry {
+        LineGeometry {
+            positions: AttributeArray::new(0, "position"),
+            colors: AttributeArray::new(1, "color"),
+            widths: AttributeArray::new(2, "width"),
+            indices: Vec::new()
+        }
+    }
+
+    /// Add line segment with given data to the line geometry.
+    pub fn add_segment(&mut self, begin: Vec3, end: Vec3, color: Vec3, width: f32) {
+        self.positions.local_buffer.push(begin);
+        self.positions.local_buffer.push(end);
+        self.colors.local_buffer.push(color.clone());
+        self.colors.local_buffer.push(color);
+        self.widths.local_buffer.push(width);
+        self.widths.local_buffer.push(width);
+
+        let index0 = self.positions.local_buffer.len() - 2;
+        let index1 = index0 + 1;
+        self.indices.push(index0 as _);
+        self.indices.push(index1 as _);
+    }
+}
+
+impl Geometry for LineGeometry {
+    fn retrieve_attributes(&self) -> Vec<&dyn AttributeArrayBase> {
+        vec![&self.positions, &self.colors, &self.widths]
+    }
+}
+
+impl IndexedGeometry for LineGeometry {
+    fn retrieve_indices(&self) -> &[u32] {
+        return &self.indices;
+    }
+}
+
+
+/// A material that uses a geometry shader to turn line segments into 2D lines
+/// based on triangle strips.
+pub struct Line2DMaterial {
+    /// The underlying shader program
+    program: Program,
+    /// The dimensions of the screen
+    pub screen_dimensions: (u32, u32)
+}
+
+impl Line2DMaterial {
+    /// Create a new instance of this material.
+    pub fn new(screen_dimensions: (u32, u32)) -> Line2DMaterial {
+        let mut shaders = vec![
+            Shader::new_vertex(Self::VERTEX_SHADER_SOURCE).unwrap(),
+            Shader::new_fragment(Self::FRAGMENT_SHADER_SOURCE).unwrap(),
+            Shader::new_geometry(Self::GEOMETRY_SHADER_SOURCE).unwrap()
+        ];
+
+        Line2DMaterial {
+            program: Program::from_shaders(
+                &mut shaders
+            ).unwrap(),
+            screen_dimensions: screen_dimensions
+        }
+    }
+}
+
+impl Material for Line2DMaterial {
+    fn enable_material(&self, params: &mut RenderParameters) {
+        self.program.use_program();
+
+        self.program.set_uniform_mat4("projection", &params.projection);
+        self.program.set_uniform_mat4("view", &params.view);
+        self.program.set_uniform_mat4("model", &params.model);
+
+        let dims = Vec2::new(self.screen_dimensions.0 as _, self.screen_dimensions.1 as _);
+        self.program.set_uniform_vec2("viewport", &dims);
+    }
+
+    /// Retrieve this instance as a reference to Any. This is used for downcasting.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Retrieve this instance as a mutable reference to Any. This is used for downcasting.
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl Line2DMaterial {
+    /// The vertex shader source for this material
+    const VERTEX_SHADER_SOURCE: &'static str = r#"
+        #version 330 core
+
+        layout (location = 0) in vec3 Position;
+        layout (location = 1) in vec3 Color;
+        layout (location = 2) in float Width; 
+
+        uniform mat4 projection;
+        uniform mat4 view;
+        uniform mat4 model;
+
+        out Vertex
+        {
+            vec4 color;
+            float width;
+        } vertex;
+
+        void main()
+        {
+            gl_Position = projection * view * model * vec4(Position, 1.0);
+            vertex.color = vec4(Color, 1.0);
+            vertex.width = Width;
+        }
+    "#;
+
+    /// The geometry shader source for this material
+    const GEOMETRY_SHADER_SOURCE: &'static str = r#"
+        #version 330 core
+
+        layout(lines) in;
+        layout(triangle_strip, max_vertices = 4) out;
+
+        // The screen dimensions in pixels
+        uniform vec2 viewport;   
+
+        in Vertex 
+        {
+            vec4 color;
+            float width;
+        } vertex[];
+
+        out vec4 vertex_color;
+
+        
+        void main()
+        {
+            float line_width = vertex[0].width;
+
+            vec3 ndc0 = gl_in[0].gl_Position.xyz / gl_in[0].gl_Position.w;
+            vec3 ndc1 = gl_in[1].gl_Position.xyz / gl_in[1].gl_Position.w;
+
+            vec2 lineScreenForward = normalize(ndc1.xy - ndc0.xy);
+            vec2 lineScreenRight = vec2(-lineScreenForward.y, lineScreenForward.x);
+            vec2 lineScreenOffset = (vec2(line_width) / viewport) * lineScreenRight;
+
+            vec4 cpos0 = gl_in[0].gl_Position;
+            gl_Position = vec4(cpos0.xy + lineScreenOffset*cpos0.w, cpos0.z, cpos0.w);
+            vertex_color = vertex[0].color;
+            EmitVertex();
+
+            vec4 cpos1 = gl_in[0].gl_Position;
+            gl_Position = vec4(cpos1.xy - lineScreenOffset*cpos1.w, cpos1.z, cpos1.w);
+            vertex_color = vertex[0].color;
+            EmitVertex();
+
+            vec4 cpos2 = gl_in[1].gl_Position;
+            gl_Position = vec4(cpos2.xy + lineScreenOffset*cpos2.w, cpos2.z, cpos2.w);
+            vertex_color = vertex[1].color;
+            EmitVertex();
+
+            vec4 cpos3 = gl_in[1].gl_Position;
+            gl_Position = vec4(cpos3.xy - lineScreenOffset*cpos3.w, cpos3.z, cpos3.w);
+            vertex_color = vertex[1].color;
+            EmitVertex();
+
+            EndPrimitive();
+        }
+    "#;
+
+    /// The fragment shader source for this material
+    const FRAGMENT_SHADER_SOURCE: &'static str = r#"
+        #version 330 core
+
+        in vec4 vertex_color;
+        out vec4 Out_Color;
+
+        void main()
+        {
+            Out_Color = vertex_color;
+        }
+    "#;
+}
+
+
+
+
+
+
+/// A material that uses a geometry shader to turn line segments into 3D lines
+/// based on triangle strips.
+pub struct Line3DMaterial {
+    /// The underlying shader program
+    program: Program
+}
+
+impl Line3DMaterial {
+    /// Create a new instance of this material.
+    pub fn new() -> Line3DMaterial {
+        let mut shaders = vec![
+            Shader::new_vertex(Self::VERTEX_SHADER_SOURCE).unwrap(),
+            Shader::new_fragment(Self::FRAGMENT_SHADER_SOURCE).unwrap(),
+            Shader::new_geometry(Self::GEOMETRY_SHADER_SOURCE).unwrap()
+        ];
+
+        Line3DMaterial {
+            program: Program::from_shaders(
+                &mut shaders
+            ).unwrap()
+        }
+    }
+}
+
+impl Material for Line3DMaterial {
+    fn enable_material(&self, params: &mut RenderParameters) {
+        self.program.use_program();
+
+        self.program.set_uniform_mat4("projection", &params.projection);
+        self.program.set_uniform_mat4("view", &params.view);
+        self.program.set_uniform_mat4("model", &params.model);
+
+        self.program.set_uniform_vec3("AmbientIntensity", &params.lighting.ambient_intensity);
+        self.program.set_uniform_vec3("DirectionalIntensity", &params.lighting.directional_intensity);
+        self.program.set_uniform_vec3("DirectionalLight", &params.lighting.directional_light);
+    }
+
+    /// Retrieve this instance as a reference to Any. This is used for downcasting.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Retrieve this instance as a mutable reference to Any. This is used for downcasting.
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl Line3DMaterial {
+    /// The vertex shader source for this material
+    const VERTEX_SHADER_SOURCE: &'static str = r#"
+        #version 330 core
+
+        layout (location = 0) in vec3 Position;
+        layout (location = 1) in vec3 Color;
+        layout (location = 2) in float Width; 
+
+        out Vertex
+        {
+            vec4 color;
+            float width;
+        } vertex;
+
+        void main()
+        {
+            gl_Position = vec4(Position, 1.0);
+            vertex.color = vec4(Color, 1.0);
+            vertex.width = Width;
+        }
+    "#;
+
+    /// The geometry shader source for this material
+    const GEOMETRY_SHADER_SOURCE: &'static str = r#"
+        #version 330 core
+
+        layout(lines) in;
+        layout(triangle_strip, max_vertices = 32) out;
+
+        uniform mat4 projection;
+        uniform mat4 view;
+        uniform mat4 model;
+
+        in Vertex 
+        {
+            vec4 color;
+            float width;
+        } vertex[];
+
+        out vec4 vertex_color;
+        out vec3 normal_vector;
+
+        vec3 createPerp(vec3 p1, vec3 p2)
+        {
+            vec3 invec = normalize(p2 - p1);
+            vec3 ret = cross( invec, vec3(0.0, 0.0, 1.0) );
+            if ( length(ret) == 0.0 )
+            {
+                ret = cross(invec, vec3(0.0, 1.0, 0.0) );
+            }
+            return ret;
+        }
+
+        
+        void main()
+        {
+            mat4 mvp = projection * view * model;
+
+            vec3 axis = gl_in[1].gl_Position.xyz - gl_in[0].gl_Position.xyz;
+
+            vec3 perpx = normalize(createPerp(gl_in[1].gl_Position.xyz, gl_in[0].gl_Position.xyz));
+            vec3 perpy = cross(normalize(axis), perpx);
+
+            float r1 = vertex[0].width / 1000.0;
+            float r2 = vertex[0].width / 1000.0;
+
+            int segs = 16;
+            for(int i=0; i<segs; i++) {
+                float a = i/float(segs-1) * 2.0 * 3.14159;
+                float ca = cos(a); float sa = sin(a);
+                vec3 normal = vec3( ca*perpx.x + sa*perpy.x,
+                                ca*perpx.y + sa*perpy.y,
+                                ca*perpx.z + sa*perpy.z );
+
+                
+
+                vec3 p1 = gl_in[0].gl_Position.xyz + r1*normal;
+                vec3 p2 = gl_in[1].gl_Position.xyz + r2*normal;
+                
+                gl_Position = mvp * vec4(p1, 1.0);
+                vertex_color = vertex[0].color;
+                normal_vector = normal;
+                EmitVertex();
+
+
+                gl_Position = mvp * vec4(p2, 1.0);
+                vertex_color = vertex[0].color;
+                normal_vector = normal;
+                EmitVertex();       
+            }
+            EndPrimitive();   
+        }
+    "#;
+
+    /// The fragment shader source for this material
+    const FRAGMENT_SHADER_SOURCE: &'static str = r#"
+        #version 330 core
+
+        uniform vec3 AmbientIntensity;
+        uniform vec3 DirectionalIntensity;
+        uniform vec3 DirectionalLight;
+
+        in vec4 vertex_color;
+        in vec3 normal_vector;
+
+        out vec4 Color;
+
+        void main()
+        {
+            vec3 ambient = AmbientIntensity;
+            
+            float diff = max(dot(normalize(normal_vector), normalize(DirectionalLight)), 0.0);
+            vec3 diffuse = diff * DirectionalIntensity;
+
+            vec3 result = (diffuse + ambient) * vertex_color.xyz;
+
+            Color = vec4(result, 1.0f);
+        }
+    "#;
+}

--- a/src/rendering/primitives/line.rs
+++ b/src/rendering/primitives/line.rs
@@ -339,7 +339,6 @@ impl Line3DMaterial {
                 normal_vector = normal;
                 EmitVertex();
 
-
                 gl_Position = mvp * vec4(p2, 1.0);
                 vertex_color = vertex[0].color;
                 normal_vector = normal;

--- a/src/rendering/primitives/mod.rs
+++ b/src/rendering/primitives/mod.rs
@@ -1,0 +1,1 @@
+pub mod line;

--- a/src/rendering/uniforms.rs
+++ b/src/rendering/uniforms.rs
@@ -1,4 +1,4 @@
-use nalgebra_glm::{Mat4, Vec3};
+use nalgebra_glm::{Mat4, Vec3, Vec2};
 use gl::types::*;
 use std::ffi::CString;
 use std::ptr;
@@ -30,6 +30,19 @@ impl Program {
                 loc,
                 1,
                 vec as *const Vec3 as *const _
+            );
+        }
+    }
+
+    /// Set Vec2 uniform on this program object
+    pub fn set_uniform_vec2(&self, name: &str, vec: &Vec2) {
+        let loc = self.query_location(name);
+
+        unsafe {
+            gl::Uniform2fv(
+                loc,
+                1,
+                vec as *const Vec2 as *const _
             );
         }
     }

--- a/src/scene/lsystem/gui.rs
+++ b/src/scene/lsystem/gui.rs
@@ -629,6 +629,20 @@ fn do_drawing_parameters(ui: &Ui, lsystem: &mut LSystemScene) {
         if Slider::<u32>::new(im_str!("Iterations"), 0..=13).build(ui, &mut lsystem.lsystem_params.iteration_depth) {
             lsystem.refresh_iteration_depth();
         }
+
+        let mut current_item: i32 = lsystem.lsystem_params.line_draw_mode as _;
+        let items = vec![im_str!("Legacy Lines"), im_str!("2D Lines"), im_str!("3D Lines")];
+
+        if ui.combo(im_str!("Line Mode"), &mut current_item, &items, 3) {
+            let new_mode = match current_item {
+                0 => LineDrawMode::Basic,
+                1 => LineDrawMode::Advanced2D,
+                _ => LineDrawMode::Advanced3D
+            };
+
+            lsystem.lsystem_params.line_draw_mode = new_mode;
+            lsystem.draw_lsystem();
+        }
     }
 }
 

--- a/src/scene/lsystem/gui.rs
+++ b/src/scene/lsystem/gui.rs
@@ -619,6 +619,28 @@ fn do_drawing_parameters(ui: &Ui, lsystem: &mut LSystemScene) {
                 modified = true;
         }
 
+        let mut line_width: f32 = params.initial_line_width as _;
+        if ui.drag_float(im_str!("Line Width"), &mut line_width)
+            .min(0.0)
+            .max(360.0)
+            .display_format(im_str!("%.2lf"))
+            .speed(0.01)
+            .build() {
+                params.initial_line_width = line_width as _;
+                modified = true;
+        }
+
+        let mut line_delta: f32 = params.line_width_delta as _;
+        if ui.drag_float(im_str!("Line Width Delta"), &mut line_delta)
+            .min(0.0)
+            .max(360.0)
+            .display_format(im_str!("%.2lf"))
+            .speed(0.01)
+            .build() {
+                params.line_width_delta = line_delta as _;
+                modified = true;
+        }
+
         if modified {
             lsystem.refresh_drawing_parameters();
         }

--- a/src/scene/lsystem/gui.rs
+++ b/src/scene/lsystem/gui.rs
@@ -665,6 +665,12 @@ fn do_drawing_parameters(ui: &Ui, lsystem: &mut LSystemScene) {
             lsystem.lsystem_params.line_draw_mode = new_mode;
             lsystem.draw_lsystem();
         }
+
+        ui.same_line(0.0);
+        help_marker(ui, im_str!("Three approaches to rendering lines are supported:\n\
+                                 \tLegacy: Renders lines using built-in OpenGL functionality. Does not support custom widths.\n\
+                                 \t2D: Uses a custom geometry shader to render lines as triangle strips. Supports arbitrary widths.\n\
+                                 \t3D: Renders lines as 3D tubes. Useful for more realistic looking models, like plants."));
     }
 }
 

--- a/src/scene/lsystem/mod.rs
+++ b/src/scene/lsystem/mod.rs
@@ -60,9 +60,7 @@ pub struct LSystemScene {
     /// Screen width
     pub width: u32,
     /// Screen height
-    pub height: u32,
-
-    pub test_mesh: Mesh
+    pub height: u32
 }
 
 impl LSystemScene {
@@ -82,33 +80,6 @@ impl LSystemScene {
         let bb = Self::calculate_bounding_box(&settings.bounding_box_color, &lsystem);
         let bezier_models = Self::retrieve_bezier_models(&lsystem, &bezier_mesh_manager);
 
-
-        // TEST BEGIN
-        let mut geom = LineGeometry::new();
-        let pos1 = Vec3::new(-0.7, 0.0, -0.3);
-        let pos2 = Vec3::new(-0.25, 0.0, -0.3);
-        let pos3 = Vec3::new(0.0, 0.0, 0.0);
-        let pos4 = Vec3::new(0.5, 0.0, 0.0);
-        let pos5 = Vec3::new(0.75, 0.0, 0.30);
-
-        geom.positions.local_buffer = vec![pos1, pos2, pos3, pos4, pos5];
-        geom.colors.local_buffer = vec![Vec3::new(0.15, 0.63, 0.045); 5];
-
-        geom.widths.local_buffer = vec![5.0; 5];
-        //geom.widths.local_buffer = vec![1.5; 5];
-        geom.indices = vec![
-            0u32, 1u32,
-            1u32, 2u32,
-            2u32, 3u32,
-            3u32, 4u32
-        ];
-
-        let mat = Box::new(Line3DMaterial::new());
-
-        let test_mesh = Mesh::new_indexed(PrimitiveType::Lines, mat, &geom);
-        // TEST END
-
-
         let mut scene = LSystemScene{
             lsystem_params: params.clone(),
             app_settings: settings.clone(),
@@ -121,8 +92,7 @@ impl LSystemScene {
             width: w,
             height: h,
             bezier_manager: bezier_mesh_manager,
-            bezier_models: bezier_models,
-            test_mesh: test_mesh
+            bezier_models: bezier_models
         };
 
         if settings.auto_center_camera {
@@ -497,8 +467,6 @@ impl Scene for LSystemScene {
                 bb.render(&mut params);
             }
         }
-
-        self.test_mesh.render(&mut params);
     }
 
     /// Perform logic. Currently, this means checking if a BezierEditorScene just ended, which would mean
@@ -549,7 +517,9 @@ impl Scene for LSystemScene {
         self.height = h;
 
         // The material in the lines mesh needs accurate viewport dimensions to function correctly
-        let mut line_mat = self.lines_mesh.retrieve_material_mut_ref::<Line2DMaterial>();
-        line_mat.screen_dimensions = (w, h);
+        if let LineDrawMode::Advanced2D = self.lsystem_params.line_draw_mode {
+            let mut line_mat = self.lines_mesh.retrieve_material_mut_ref::<Line2DMaterial>();
+            line_mat.screen_dimensions = (w, h);
+        }
     }
 }


### PR DESCRIPTION
This PR implements two new line rendering methods, while retaining the legacy approach for compatibility. This is done since the legacy approach using OpenGL's built-in `GL_LINES` functionality lacks the ability to use arbitrary line widths (especially since the supported line width is driver-dependant) and, more importantly, specifying the line width on a per-vertex basis using attributes (it only supports modifying it by changing OpenGL state using the `glLineWidth` function).

The two new methods are:
- **2D Lines:** Renders 2D lines made out of triangle strips using a custom geometry shader.
- **3D Lines:** Renders lines as 3D tubes.

